### PR TITLE
2016-02-02 (gunnersson): added file-extension for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,4 @@ Things, that will not be included:
 
 You're welcome to fork the project to create profiles with such features enabled.
 Later some plugin system may be added. Then additional settings / addons could just be added via a config file.
+


### PR DESCRIPTION
you used MarkDown language like here: [CanvasBlocker@kkapsner.de.xpi](https://addons.mozilla.org/en-US/firefox/addon/canvasblocker/)

to be displayed properly, README file needs extension .md

N.B. when there's a txt file of MarkDown language, please set .md file-extension.