### PR TITLE
Create trim_urls.json

### DIFF
--- a/settings/trim_urls.json
+++ b/settings/trim_urls.json
@@ -1,0 +1,13 @@
+[
+    {
+        "name": "trim_urls", 
+        "type": "boolean", 
+        "initial": true, 
+        "label": "Trim URLs in navigation bar", 
+        "help_text": "By default Firefox trims many URLs (hiding the http:// prefix and trailing slash /). Set to false to show all parts of the URL (i.e. https:// prefix).", 
+        "addons": [], 
+        "config": {
+            "browser.urlbar.trimURLs": false
+        }
+    }
+]


### PR DESCRIPTION
Add 'browser.urlbar.trimURLs' config setting. (see Mozilla explanation here: https://developer.mozilla.org/en-US/docs/Mozilla/Preferences/Preference_reference/browser.urlbar.trimURLs).

For me this is part of the Firefox 'Annoyances', i like to see if the website uses http or http**s**.
