### PR TITLE
Disable check for captive portal.

### DIFF
--- a/settings/captive_portal_service.json
+++ b/settings/captive_portal_service.json
@@ -1,0 +1,12 @@
+[
+    {
+        "name": "captive_portal_service",
+        "type": "boolean",
+        "label": "Disable check for captive portal.",
+        "help_text": "By default, Firefox checks for the presence of a captive portal on every startup.  This usually involves traffic to Akamai.  See `https://support.mozilla.org/en-US/questions/1169302`.",
+        "initial": true,
+        "config": {
+            "network.captive-portal-service.enabled": false
+        },
+    }
+]


### PR DESCRIPTION
By default, Firefox checks for the presence of a captive portal on
every startup.  This usually involves traffic to Akamai, see [1].
Disabling this should not have negative effects if you are not behind
a captive portal.  For most desktop installations, this should be the
case.

____________________
[1] https://support.mozilla.org/en-US/questions/1169302