### PR TITLE
Disable Speculative loading

### DIFF
--- a/settings/speculative_loading.json
+++ b/settings/speculative_loading.json
@@ -3,7 +3,7 @@
         "name": "speculative_loading",
         "type": "boolean",
         "label": "Disable speculative website loading.",
-        "help_text": "",
+        "help_text": "In some situations Firefox already starts loading web pages when the mouse pointer is over a link, i. e. before you actually click. This is to speed up the loading of web pages by a few milliseconds.",
         "initial": true,
         "config": {
             "network.http.speculative-parallel-limit": "0"

--- a/settings/speculative_loading.json
+++ b/settings/speculative_loading.json
@@ -1,0 +1,13 @@
+[
+    {
+        "name": "speculative_loading",
+        "type": "boolean",
+        "label": "Disable speculative website loading.",
+        "help_text": "",
+        "initial": true,
+        "config": {
+            "network.http.speculative-parallel-limit": "0"
+        },
+    }
+]
+


### PR DESCRIPTION
In some situations Firefox already starts loading web pages when the mouse pointer is over a link, i. e. before you actually click. This is to speed up the loading of web pages by a few milliseconds.

A request to a link, if it has not even been clicked, should not be.
This should be disabled in a privacy Firefox profile!