### PR TITLE
Disable Google safebrowsing completely

### DIFF
--- a/settings/google_safebrowsing.json
+++ b/settings/google_safebrowsing.json
@@ -3,8 +3,8 @@
         "name": "google_safebrowsing", 
         "type": "boolean", 
         "initial": true, 
-        "label": "Disable google safebrowsing completly", 
-        "help_text": "Google safebrowsing can detect pishing and malware but it also sends informations about to google.", 
+        "label": "Disable google safebrowsing completely", 
+        "help_text": "Google safebrowsing can detect pishing and malware but it also sends informations to google.", 
         "addons": [], 
         "config": {
             "browser.safebrowsing.downloads.remote.url": "", 

--- a/settings/google_safebrowsing.json
+++ b/settings/google_safebrowsing.json
@@ -3,10 +3,11 @@
         "name": "google_safebrowsing", 
         "type": "boolean", 
         "initial": true, 
-        "label": "Disable google safebrowsing completely", 
-        "help_text": "Google safebrowsing can detect pishing and malware but it also sends informations to google.", 
+        "label": "Disable google safebrowsing", 
+        "help_text": "Google safebrowsing can detect pishing and malware but it also sends informations to google together with an unique key(<a href=\"http://electroholiker.de/?p=1594\">wrkey</a>).", 
         "addons": [], 
         "config": {
+            "browser.safebrowsing.enabled": false,
             "browser.safebrowsing.downloads.remote.url": "", 
             "browser.safebrowsing.phishing.enabled": false, 
             "browser.safebrowsing.blockedURIs.enabled": false, 

--- a/settings/google_safebrowsing.json
+++ b/settings/google_safebrowsing.json
@@ -1,0 +1,21 @@
+[
+    {
+        "name": "google_safebrowsing", 
+        "type": "boolean", 
+        "initial": true, 
+        "label": "Disable google safebrowsing completly", 
+        "help_text": "Google safebrowsing can detect pishing and malware but it also sends informations about to google.", 
+        "addons": [], 
+        "config": {
+            "browser.safebrowsing.downloads.remote.url": "", 
+            "browser.safebrowsing.phishing.enabled": false, 
+            "browser.safebrowsing.blockedURIs.enabled": false, 
+            "browser.safebrowsing.downloads.enabled": false,
+            "browser.safebrowsing.downloads.remote.enabled": false,
+            "browser.safebrowsing.appRepURL": "", 
+            "browser.safebrowsing.malware.enabled": false
+
+        }
+    }
+]
+


### PR DESCRIPTION
You only disabled the malware scan.
There should also be an option to disable all connections from Firefox to Google safebrowsing. Phishing attacks are not completely protected by technical measures, but primarily by one's own behaviour. And regular updates of the system protect against malware better than virus scanners and URL lists.