### PR TITLE
Disable addon blocklist (KillSwitch)

### DIFF
--- a/settings/addon_killswitch.json
+++ b/settings/addon_killswitch.json
@@ -1,0 +1,12 @@
+[
+    {
+        "name": "addon_killswitch",
+        "type": "boolean",
+        "label": "Disable extensions blocklist from mozilla.",
+        "help_text": "The blocklist extension (https://blocked.cdn.mozilla.net/) can use Mozilla to deactivate individual add-ons in the browser. It is practically a kill switch for Firefox add-ons and plug-ins. Updating the block list transfers detailed information about the real browser and operating system to Mozilla.",
+        "initial": true,
+        "config": {
+            "extensions.blocklist.enabled": false
+        },
+    }
+]


### PR DESCRIPTION
The [extension blocklist](https://blocked.cdn.mozilla.net/) can use Mozilla to disable individual add-ons in the browser. It is practically a kill switch for Firefox add-ons and plug-ins. Updating the block list transfers detailed information about the real browser and operating system to Mozilla.

This looks for example like:

```
https://addons.mozilla.org/blocklist/3/%7Bec8030f7-c20a
-464f-9b0e-13a3a9e97384%7D/10.0.5/Firefox/20120608001639
/Linux_x86-gcc3/en-US/default/Linux%202.6.37.6-smp%20
(GTK%202.24.4)/default/default/20/20/3/
```