### PR TITLE
Firstparty-Isolation

### DIFF
--- a/settings/firstparty-isolation.json
+++ b/settings/firstparty-isolation.json
@@ -7,7 +7,7 @@
         "help_text": "FPI works by separating cookies on a per-domain basis. In this way tracking networks won't be able to locate the same cookie on different sites.", 
         "addons": [], 
         "config": {
-            "privacy.firstparty.isolate": true
+            "privacy.firstparty.isolate": false
         }
     }
 ]

--- a/settings/firstparty-isolation.json
+++ b/settings/firstparty-isolation.json
@@ -7,7 +7,7 @@
         "help_text": "FPI works by separating cookies on a per-domain basis. In this way tracking networks won't be able to locate the same cookie on different sites. Note that this might break third-party logins.", 
         "addons": [], 
         "config": {
-            "privacy.firstparty.isolate": false
+            "privacy.firstparty.isolate": true
         }
     }
 ]

--- a/settings/firstparty-isolation.json
+++ b/settings/firstparty-isolation.json
@@ -1,0 +1,13 @@
+[
+    {
+        "name": "firstparty-isolation", 
+        "type": "boolean", 
+        "initial": true, 
+        "label": "Enable firstparty isolation.", 
+        "help_text": "FPI works by separating cookies on a per-domain basis. In this way tracking networks won't be able to locate the same cookie on different sites.", 
+        "addons": [], 
+        "config": {
+            "privacy.firstparty.isolate": true
+        }
+    }
+]

--- a/settings/firstparty-isolation.json
+++ b/settings/firstparty-isolation.json
@@ -2,9 +2,9 @@
     {
         "name": "firstparty-isolation", 
         "type": "boolean", 
-        "initial": true, 
+        "initial": false, 
         "label": "Enable firstparty isolation.", 
-        "help_text": "FPI works by separating cookies on a per-domain basis. In this way tracking networks won't be able to locate the same cookie on different sites.", 
+        "help_text": "FPI works by separating cookies on a per-domain basis. In this way tracking networks won't be able to locate the same cookie on different sites. Note that this might break third-party logins.", 
         "addons": [], 
         "config": {
             "privacy.firstparty.isolate": false


### PR DESCRIPTION
This enables the Firstparty-Isolation in Firefox. Though it might break third-party logins (Google/Facebook/...) I do recommend disabling it by default.