### PR TITLE
send DNS over HTTP via cloudflare

### DIFF
--- a/settings/doh-trr.json
+++ b/settings/doh-trr.json
@@ -1,0 +1,13 @@
+[
+   {
+      "name" : "doh-trr",
+      "initial" : 0,
+      "help_text" : "DNS over HTTP (DoH), aka. <a href=\"https://wiki.mozilla.org/Trusted_Recursive_Resolver\">Trusted Recursive Resolver (TRR)</a>, might be introduced soon and send all DNS queries to Cloudflare, a company under US legislation.  Set this to `5` to disable this feature.",
+      "addons" : [],
+      "label" : "How to use DoH TRR.",
+      "config" : {
+         "network.trr.mode" : 5
+      },
+      "type" : "number"
+   }
+]


### PR DESCRIPTION
Hi, you really need to review this, but it should disable the TRR feature that is being prepared by mozilla right now.  That would send all DNS queries to cloudflare.  See `https://wiki.mozilla.org/Trusted_Recursive_Resolver`