### PR TITLE
Strip locale from mozilla.org URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ The Extension needs to have the name of its install.rdf file.
 
 Currently they are:
 
-- [CanvasBlocker@kkapsner.de.xpi](https://addons.mozilla.org/en-US/firefox/addon/canvasblocker/)
-- [jid1-zUrvDCat3xoDSQ@jetpack.xpi](https://addons.mozilla.org/de/firefox/addon/google-no-tracking-url/)
-- [https-everywhere@eff.org.xpi](https://addons.mozilla.org/en-US/firefox/addon/https-everywhere/)
-- [uBlock0@raymondhill.net.xpi](https://addons.mozilla.org/en-US/firefox/addon/ublock-origin/)
-- [uMatrix@raymondhill.net.xpi](https://addons.mozilla.org/en-US/firefox/addon/umatrix/)
+- [CanvasBlocker@kkapsner.de.xpi](https://addons.mozilla.org/firefox/addon/canvasblocker/)
+- [jid1-zUrvDCat3xoDSQ@jetpack.xpi](https://addons.mozilla.org/firefox/addon/google-no-tracking-url/)
+- [https-everywhere@eff.org.xpi](https://addons.mozilla.org/firefox/addon/https-everywhere/)
+- [uBlock0@raymondhill.net.xpi](https://addons.mozilla.org/firefox/addon/ublock-origin/)
+- [uMatrix@raymondhill.net.xpi](https://addons.mozilla.org/firefox/addon/umatrix/)
 - [privacy_badger-2018.8.22-an+fx.xpi](https://addons.cdn.mozilla.net/user-media/addons/506646/privacy_badger-2017.1.26.1-an+fx.xpi)
 
 Things, that will not be included:

--- a/settings/canvasblocker.json
+++ b/settings/canvasblocker.json
@@ -3,7 +3,7 @@
         "name": "canvasblocker", 
         "type": "boolean", 
         "initial": true, 
-        "label": "Install <a href=\"https://addons.mozilla.org/en-US/firefox/addon/canvasblocker/\">CanvasBlocker</a> extension.", 
+        "label": "Install <a href=\"https://addons.mozilla.org/firefox/addon/canvasblocker/\">CanvasBlocker</a> extension.", 
         "help_text": "Blocks the JS-API for the &lt;canvas&gt; element to prevent <a href=\"https://en.wikipedia.org/wiki/Canvas_fingerprinting\">Canvas-Fingerprinting</a>.", 
         "addons": [
             "CanvasBlocker@kkapsner.de.xpi"

--- a/settings/captive_portal_service.json
+++ b/settings/captive_portal_service.json
@@ -3,7 +3,7 @@
         "name": "captive_portal_service",
         "type": "boolean",
         "label": "Disable check for captive portal.",
-        "help_text": "By default, Firefox checks for the presence of a captive portal on every startup.  This involves <a href=\"https://support.mozilla.org/en-US/questions/1169302\">traffic to Akamai</a>.",
+        "help_text": "By default, Firefox checks for the presence of a captive portal on every startup.  This involves <a href=\"https://support.mozilla.org/questions/1169302\">traffic to Akamai</a>.",
         "initial": true,
         "addons": [],
         "config": {

--- a/settings/crash_reports.json
+++ b/settings/crash_reports.json
@@ -4,7 +4,7 @@
         "type": "boolean", 
         "initial": true, 
         "label": "Disable Crash Reports", 
-        "help_text": "The <a href=\"https://www.mozilla.org/en-US/privacy/firefox/#crash-reporter\">crash report</a> may contain data that identifies you or is otherwise sensitive to you.", 
+        "help_text": "The <a href=\"https://www.mozilla.org/privacy/firefox/#crash-reporter\">crash report</a> may contain data that identifies you or is otherwise sensitive to you.", 
         "addons": [], 
         "config": {
             "breakpad.reportURL": "",

--- a/settings/google_redirect_cleaner.json
+++ b/settings/google_redirect_cleaner.json
@@ -3,7 +3,7 @@
         "name": "google_redirect_cleaner", 
         "type": "boolean", 
         "initial": true, 
-        "label": "Install <a href=\"https://addons.mozilla.org/de/firefox/addon/google-no-tracking-url/\">Google Redirects Fixer &amp; Tracking Remover</a> extension.", 
+        "label": "Install <a href=\"https://addons.mozilla.org/firefox/addon/google-no-tracking-url/\">Google Redirects Fixer &amp; Tracking Remover</a> extension.", 
         "help_text": "Rewrites URLs from the google result pages to from redirect urls with tracking to direct links.", 
         "addons": [
             "jid1-zUrvDCat3xoDSQ@jetpack.xpi"

--- a/settings/health_report.json
+++ b/settings/health_report.json
@@ -4,7 +4,7 @@
         "type": "boolean", 
         "initial": true, 
         "label": "Disable health report", 
-        "help_text": "Disable sending <a href=\"https://www.mozilla.org/en-US/privacy/firefox/#health-report\">Firefox health reports</a> to Mozilla", 
+        "help_text": "Disable sending <a href=\"https://www.mozilla.org/privacy/firefox/#health-report\">Firefox health reports</a> to Mozilla", 
         "addons": [], 
         "config": {
             "datareporting.healthreport.uploadEnabled": false, 

--- a/settings/https_everywhere.json
+++ b/settings/https_everywhere.json
@@ -3,7 +3,7 @@
         "name": "https_everywhere", 
         "type": "boolean", 
         "initial": true, 
-        "label": "Install the <a href=\"https://addons.mozilla.org/en-US/firefox/addon/https-everywhere/\">HTTPS Everywhere</a> extension.", 
+        "label": "Install the <a href=\"https://addons.mozilla.org/firefox/addon/https-everywhere/\">HTTPS Everywhere</a> extension.", 
         "help_text": "HTTPS Everywhere is a Firefox extension that  enables HTTPS encryption automatically on sites that support it.", 
         "addons": [
             "https-everywhere@eff.org.xpi"

--- a/settings/media_devices.json
+++ b/settings/media_devices.json
@@ -4,7 +4,7 @@
         "type": "boolean", 
         "initial": true, 
         "label": "Disable media device queries", 
-        "help_text": "Prevent websites from accessing <a href=\"https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/enumerateDevices\">information about webcam and microphone</a> (possible fingerprinting).", 
+        "help_text": "Prevent websites from accessing <a href=\"https://developer.mozilla.org/docs/Web/API/MediaDevices/enumerateDevices\">information about webcam and microphone</a> (possible fingerprinting).", 
         "addons": [], 
         "config": {
             "media.navigator.enabled": false

--- a/settings/privacybadger.json
+++ b/settings/privacybadger.json
@@ -11,6 +11,6 @@
         "config": {}, 
         "initial": true, 
         "type": "boolean", 
-        "label": "Install the <a href=\"https://addons.mozilla.org/en-US/firefox/addon/privacy-badger17/\">Privacy Badger</a> extension."
+        "label": "Install the <a href=\"https://addons.mozilla.org/firefox/addon/privacy-badger17/\">Privacy Badger</a> extension."
     }
 ]

--- a/settings/referer.json
+++ b/settings/referer.json
@@ -17,7 +17,7 @@
             [], 
             [] 
         ], 
-        "help_text": "Firefox tells a website, from which site you're coming (the so called <a href=\"http://kb.mozillazine.org/Network.http.sendRefererHeader\">referer</a>). You can find more detailed settings in this <a href=\"http://www.ghacks.net/2015/01/22/improve-online-privacy-by-controlling-referrer-information/\">ghacks article</a> or install the <a href=\"https://addons.mozilla.org/en-US/firefox/addon/refcontrol/\">RefControl</a> extension for per domain settings.", 
+        "help_text": "Firefox tells a website, from which site you're coming (the so called <a href=\"http://kb.mozillazine.org/Network.http.sendRefererHeader\">referer</a>). You can find more detailed settings in this <a href=\"http://www.ghacks.net/2015/01/22/improve-online-privacy-by-controlling-referrer-information/\">ghacks article</a> or install the <a href=\"https://addons.mozilla.org/firefox/addon/refcontrol/\">RefControl</a> extension for per domain settings.", 
         "config": [
             {
                 "network.http.sendRefererHeader": 0

--- a/settings/telemetry.json
+++ b/settings/telemetry.json
@@ -4,7 +4,7 @@
         "type": "boolean", 
         "initial": true, 
         "label": "Disable Telemetry", 
-        "help_text": "The <a href=\"https://support.mozilla.org/en-US/kb/share-telemetry-data-mozilla-help-improve-firefox\">telemetry feature</a> sends data about the performance and responsiveness of Firefox to Mozilla.", 
+        "help_text": "The <a href=\"https://support.mozilla.org/kb/share-telemetry-data-mozilla-help-improve-firefox\">telemetry feature</a> sends data about the performance and responsiveness of Firefox to Mozilla.", 
         "addons": [], 
         "config": {
             "toolkit.telemetry.enabled": false,

--- a/settings/ublock.json
+++ b/settings/ublock.json
@@ -3,7 +3,7 @@
         "name": "ublock", 
         "type": "boolean", 
         "initial": true, 
-        "label": "Install <a href=\"https://addons.mozilla.org/en-US/firefox/addon/ublock-origin/\">uBlock Origin</a> extension.", 
+        "label": "Install <a href=\"https://addons.mozilla.org/firefox/addon/ublock-origin/\">uBlock Origin</a> extension.", 
         "help_text": "Efficient blocker, which does not only block ads, but also supports Anti-Tracking and Anti-Malware Blocklists", 
         "addons": [
             "uBlock0@raymondhill.net.xpi"

--- a/settings/umatrix.json
+++ b/settings/umatrix.json
@@ -3,7 +3,7 @@
         "name": "umatrix", 
         "type": "boolean", 
         "initial": false, 
-        "label": "Install <a href=\"https://addons.mozilla.org/en-US/firefox/addon/umatrix/\">uMatrix</a> extension.", 
+        "label": "Install <a href=\"https://addons.mozilla.org/firefox/addon/umatrix/\">uMatrix</a> extension.", 
         "help_text": "A content blocker for advanced users, which blocks requests to thirdparty domains. Big privacy gain, but you will need to configure exception rules for many sites.", 
         "addons": [
             "uMatrix@raymondhill.net.xpi"


### PR DESCRIPTION
Let the website get the locale from the user instead of forcing him to
read German (or English).