### PR TITLE
Undefined name: files --> files_inline

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -64,7 +64,7 @@ class ConfigForm(forms.Form):
                     if "addons" in option:
                         addons += option['addons'][choice]
                     if 'files_inline' in option:
-                        files.update(option['files_inline'][choice])
+                        files_inline.update(option['files_inline'][choice])
                 elif option['type'] == "text":
                     if option.get('blank_means_default', False) and self.cleaned_data[option['name']] == "":
                         continue


### PR DESCRIPTION
__files__ is an _undefined name_ in this context which has the potential to raise NameError at runtime.  This PR proposes to use __files_inline__ instead.

[flake8](http://flake8.pycqa.org) testing of https://github.com/allo-/firefox-profilemaker on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./forms.py:67:25: F821 undefined name 'files'
                        files.update(option['files_inline'][choice])
                        ^
1     F821 undefined name 'files'
1
```