### PR TITLE
Clarify warning text for indexed_db.json

### DIFF
--- a/settings/indexed_db.json
+++ b/settings/indexed_db.json
@@ -4,7 +4,7 @@
         "type": "boolean", 
         "initial": true, 
         "label": "Disable IndexedDB", 
-        "help_text": "<a href=\"http://www.w3.org/TR/IndexedDB/\">IndexedDB</a> is a way, websites can store structured data. This can be <a href=\"http://arstechnica.com/apple/2010/09/rldguid-tracking-cookies-in-safari-database-form/\">abused for tracking</a>, too. Disabling may be a problem with some webapps like tweetdeck.", 
+        "help_text": "<a href=\"http://www.w3.org/TR/IndexedDB/\">IndexedDB</a> is a way, websites can store structured data. This can be <a href=\"http://arstechnica.com/apple/2010/09/rldguid-tracking-cookies-in-safari-database-form/\">abused for tracking</a>, too. Disabling may cause problems (like crashed browser tab) with some websites like tweetdeck or reddit.", 
         "addons": [], 
         "config": {
             "dom.indexedDB.enabled": false


### PR DESCRIPTION
Disabling indexedDB may actually cause browser tabs to crash; also, it happens not only with webapps but nowadays also with normal websites.