### PR TITLE
add https_only, started from Firefox 76

### DIFF
--- a/profiles/01_default.json
+++ b/profiles/01_default.json
@@ -62,6 +62,7 @@
         "Security": [
             "autoupdate.json", 
             "extension_blocklist.json",
+            "https_only.json",
             "punycode.json"
         ], 
         "Addons": [

--- a/settings/https_only.json
+++ b/settings/https_only.json
@@ -1,0 +1,13 @@
+[
+    {
+        "name": "https_only", 
+        "type": "boolean", 
+        "initial": true, 
+        "label": "Use only HTTPS on sites", 
+        "help_text": "",
+        "addons": [], 
+        "config": {
+            "dom.security.https_only_mode": true
+        }
+    }
+]


### PR DESCRIPTION
i guess https_everywhere should be removed