### PR TITLE
Add a Dockerfile for the build and run

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+venv
+project

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 project/
 venv/
+extensions/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# docker run -it --rm --name profilemaker -v $PWD:/code -w /code python:3.8.5-alpine3.12 /bin/sh
+
+# First stage
+FROM python:3.8.5-alpine3.12 AS builder
+COPY requirements.txt .
+
+# Install dependencies to the local user directory (eg. /root/.local)
+RUN pip install --no-cache-dir --user --no-warn-script-location -r requirements.txt
+
+# Second unnamed stage
+FROM python:3.8.5-alpine3.12
+
+RUN apk add --no-cache make bash
+
+WORKDIR /code
+
+# Copy only the dependencies installation from the 1st stage image
+COPY --from=builder /root/.local /root/.local
+
+# Update PATH environment variable
+ENV PATH=/root/.local/bin:$PATH
+
+# Copy sources
+COPY . .
+
+RUN make create-project
+
+EXPOSE 8000
+
+# Run server
+CMD [ "./project/manage.py", "runserver", "0.0.0.0:8000"]

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -34,3 +34,12 @@ urlpatterns += staticfiles_urlpatterns()
   - Manually edit ``project/settings.py`` (as mentionned during the install)
 - Run the server: `make run`
 - Clean the project: `make remove`
+
+## Docker
+
+- `make build`: build the docker image
+- `make up`: run the container
+- `make down`: stop the container
+- `make shell`: open a shell on the running container
+
+> :information_source: The addons should be placed in the `extensions` folder as well

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,7 @@ SHELL = bash
 run:
 	@echo Run server
 	. venv/bin/activate
-	cd project
-	./manage.py runserver
+	./project/manage.py runserver
 
 .PHONY: install
 install: remove
@@ -15,6 +14,10 @@ install: remove
 	. venv/bin/activate
 	@echo Install dependencies
 	pip install -r requirements.txt
+	make -s create-project
+
+.PHONY: create-project
+create-project:
 	@echo Create django project
 	django-admin.py startproject project
 	@echo Create symlink
@@ -52,3 +55,19 @@ install: remove
 remove:
 	@echo "Erase 'venv' & 'project' directories"
 	rm -rf venv project
+
+.PHONY: up
+up:
+	docker run -d --rm --name profilemaker -p 8000:8000 -v ${PWD}/extensions:/code/extensions firefox-profilemaker:latest
+
+.PHONY: down
+down:
+	docker stop profilemaker
+
+.PHONY: build
+build:
+	docker build . -t firefox-profilemaker:latest
+
+.PHONY: shell
+shell:
+	docker exec -it profilemaker /bin/sh

--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@ Things, that will not be included:
 - Your favourite performance setting. It's not the scope of the project and not all people need the same performance settings.
 
 You're welcome to create an own [profile](profiles/) for such settings or fork the whole project.
+For that, you can check the [installation](INSTALL.md) procedure.


### PR DESCRIPTION
Hi,

I added the possibility to build and run a docker image.

For that I put a part of the automatic procedure into a script file so that both the local install and the dockerfile could profit from this and to avoid code duplication.

Both automatic procedure and docker image work fine, including the addons download.

Also, I added a link to the INSTALL.md file from the README.md.
I did not see it at first glance and I was glad to discover it.
