### PR TITLE
Add parameters and addons from privacytools.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,12 @@ Currently they are:
 - [https-everywhere@eff.org.xpi](https://addons.mozilla.org/firefox/addon/https-everywhere/)
 - [uBlock0@raymondhill.net.xpi](https://addons.mozilla.org/firefox/addon/ublock-origin/)
 - [uMatrix@raymondhill.net.xpi](https://addons.mozilla.org/firefox/addon/umatrix/)
-- [jid1-MnnxcxisBPnSXQ@jetpack.xpi](https://addons.cdn.mozilla.net/user-media/addons/506646/privacy_badger-2017.1.26.1-an+fx.xpi)
-- [CookieAutoDelete@kennydo.com.xpi](https://addons.mozilla.org/firefox/downloads/file/954445/cookie_autodelete-2.2.0-an+fx.xpi)
+- [jid1-MnnxcxisBPnSXQ@jetpack.xpi](https://addons.mozilla.org/en-US/firefox/addon/privacy-badger17/)
+- [CookieAutoDelete@kennydo.xpi](https://addons.mozilla.org/en-US/firefox/addon/cookie-autodelete/)
+- [Decentraleyes@ThomasRientjes.xpi](https://addons.mozilla.org/en-US/firefox/addon/decentraleyes/)
+- [ClearURLs@kevinr.xpi](https://addons.mozilla.org/en-US/firefox/addon/clearurls/)
+- [TemporaryContainers@stoically.xpi](https://addons.mozilla.org/en-US/firefox/addon/temporary-containers/)
+- [FirefoxMulti-AccountContainers@mozilla.org.xpi](https://addons.mozilla.org/en-US/firefox/addon/multi-account-containers/)
 
 Things, that will not be included:
 

--- a/profiles/01_default.json
+++ b/profiles/01_default.json
@@ -26,7 +26,9 @@
             "newtab_preload.json",
             "addons_pane.json",
             "captive_portal_service.json",
-            "screenshot.json"
+            "screenshot.json",
+            "media_drm.json",
+            "media_widevinecdm.json"
         ], 
         "Privacy": [
             "useragent.json", 
@@ -35,6 +37,7 @@
             "dom_storage.json", 
             "indexed_db.json", 
             "offline_cache.json",
+            "sessionstore_privacy.json",
             "prefetch_next.json", 
             "speculative_loading.json", 
             "newtab_page_thumbnails_container.json",
@@ -72,6 +75,10 @@
             "ublock.json", 
             "cookieautodelete.json",
             "umatrix.json",
+            "decentraleyes.json",
+            "clearurls.json",
+            "temporarycontainers.json",
+            "firefoxmulti-accountcontainers.json",
             "greasemonkey_stats.json"
         ],
         "Enterprise Policies": [

--- a/settings/canvasblocker.json
+++ b/settings/canvasblocker.json
@@ -14,7 +14,7 @@
         "enterprise_policy": {
 			"ExtensionSettings": {
 				"CanvasBlocker@kkapsner.net": {
-					"install_url": "https://addons.mozilla.org/firefox/downloads/file/3488342/canvasblocker-1.0-an+fx.xpi",
+					"install_url": "https://addons.mozilla.org/firefox/downloads/latest/canvasblocker/latest.xpi",
 					"installation_mode": "normal_installed"
 				}
 			}

--- a/settings/clearurls.json
+++ b/settings/clearurls.json
@@ -1,0 +1,23 @@
+[
+    {
+        "name": "clearurls",
+        "type": "boolean",
+        "initial": true,
+        "label": "Install <a href=\"https://gitlab.com/KevinRoebert/ClearUrls\">ClearURLs</a> extension.",
+        "help_text": "This addon will automatically remove tracking elements from URLs to help protect your privacy when browsing through the Internet.",
+        "addons": [
+            "ClearURLs@kevinr.xpi"
+        ],
+        "config": {
+            "extensions.ClearURLs@kevinr.whiteList": ""
+        },
+        "enterprise_policy": {
+			"ExtensionSettings": {
+				"ClearURLs@kevinr": {
+					"install_url": "https://addons.mozilla.org/firefox/downloads/latest/clearurls/latest.xpi",
+					"installation_mode": "normal_installed"
+				}
+			}
+		}
+    }
+]

--- a/settings/decentraleyes.json
+++ b/settings/decentraleyes.json
@@ -1,0 +1,23 @@
+[
+    {
+        "name": "decentraleyes",
+        "type": "boolean",
+        "initial": false,
+        "label": "Install <a href=\"https://decentraleyes.org\">Decentraleyes</a> extension.",
+        "help_text": "Emulates Content Delivery Networks locally by intercepting requests, finding the required resource, and injecting it into the environment.",
+        "addons": [
+            "Decentraleyes@ThomasRientjes.xpi"
+        ],
+        "config": {
+            "extensions.Decentraleyes@ThomasRientjes.whiteList": ""
+        },
+        "enterprise_policy": {
+			"ExtensionSettings": {
+				"Decentraleyes@ThomasRientjes": {
+					"install_url": "https://addons.mozilla.org/firefox/downloads/latest/decentraleyes/latest.xpi",
+					"installation_mode": "normal_installed"
+				}
+			}
+		}
+    }
+]

--- a/settings/firefoxmulti-accountcontainers.json
+++ b/settings/firefoxmulti-accountcontainers.json
@@ -1,0 +1,23 @@
+[
+    {
+        "name": "firefoxmulti-accountcontainers",
+        "type": "boolean",
+        "initial": true,
+        "label": "Install <a href=\"https://support.mozilla.org/en-US/kb/containers\">Firefox Multi-Account Containers</a> extension.",
+        "help_text": "Allow you to create containers for specific websites.",
+        "addons": [
+            "FirefoxMulti-AccountContainers@mozilla.org.xpi"
+        ],
+        "config": {
+            "extensions.FirefoxMulti-AccountContainers@mozilla.whiteList": ""
+        },
+        "enterprise_policy": {
+			"ExtensionSettings": {
+				"FirefoxMulti-AccountContainers@mozilla.org": {
+					"install_url": "https://addons.mozilla.org/firefox/downloads/latest/multi-account-containers/latest.xpi",
+					"installation_mode": "normal_installed"
+				}
+			}
+		}
+    }
+]

--- a/settings/media_drm.json
+++ b/settings/media_drm.json
@@ -1,0 +1,13 @@
+[
+    {
+        "name": "media_drm",
+        "type": "boolean",
+        "initial": true,
+        "label": "Disables playback of DRM-controlled HTML5 content",
+        "help_text": "if enabled, automatically downloads the Widevine Content Decryption Module provided by Google Inc. <a href=\"https://support.mozilla.org/en-US/kb/enable-drm#w_opt-out-of-cdm-playback-uninstall-cdms-and-stop-all-cdm-downloads\">Details</a>",
+        "addons": [],
+        "config": {
+            "media.eme.enabled": false
+        }
+    }
+]

--- a/settings/media_widevinecdm.json
+++ b/settings/media_widevinecdm.json
@@ -1,0 +1,13 @@
+[
+    {
+        "name": "media_widevinecdm",
+        "type": "boolean",
+        "initial": true,
+        "label": "Disables the Widevine Content Decryption Module provided by Google Inc.",
+        "help_text": "Used for the playback of DRM-controlled HTML5 content <a href=\"https://support.mozilla.org/en-US/kb/enable-drm#w_disable-the-google-widevine-cdm-without-uninstalling\">Details</a>",
+        "addons": [],
+        "config": {
+            "media.gmp-widevinecdm.enabled": false
+        }
+    }
+]

--- a/settings/prefetch_next.json
+++ b/settings/prefetch_next.json
@@ -7,8 +7,11 @@
         "help_text": "Firefox prefetches the next site on some links, so the site is loaded even when you never click.", 
         "addons": [], 
         "config": {
-            "network.prefetch-next": false, 
-            "network.dns.disablePrefetch": true
+            "network.prefetch-next": false,
+            "network.dns.disablePrefetch": true,
+            "network.dns.disablePrefetchFromHTTPS": true,
+            "network.predictor.enabled": false,
+            "network.predictor.enable-prefetch": false
         },
         "enterprise_policy": {
             "NetworkPrediction": false

--- a/settings/referer.json
+++ b/settings/referer.json
@@ -1,44 +1,43 @@
 [
     {
         "choices": [
-            "Always disable referer", 
-            "Send referer only on the same domain", 
-            "Spoof referer (send the same url)", 
-            "Trim referer to the domain name", 
-            "Allow real referer when clicking a link", 
+            "Always disable referer",
+            "Send referer only on the same domain",
+            "Spoof referer (send the same url)",
+            "Trim referer to the domain name",
+            "Allow real referer when clicking a link",
             "Always allow real referer"
-        ], 
-        "name": "referer", 
+        ],
+        "name": "referer",
         "addons": [
-            [], 
-            [], 
-            [], 
-            [], 
-            [], 
-            [] 
-        ], 
-        "help_text": "Firefox tells a website, from which site you're coming (the so called <a href=\"http://kb.mozillazine.org/Network.http.sendRefererHeader\">referer</a>). You can find more detailed settings in this <a href=\"http://www.ghacks.net/2015/01/22/improve-online-privacy-by-controlling-referrer-information/\">ghacks article</a> or install the <a href=\"https://addons.mozilla.org/firefox/addon/refcontrol/\">RefControl</a> extension for per domain settings.", 
+            [],
+            [],
+            [],
+            [],
+            [],
+            []
+        ],
+        "help_text": "Firefox tells a website, from which site you're coming (the so called <a href=\"http://kb.mozillazine.org/Network.http.sendRefererHeader\">referer</a>). You can find more detailed settings in this <a href=\"http://www.ghacks.net/2015/01/22/improve-online-privacy-by-controlling-referrer-information/\">ghacks article</a> or install the <a href=\"https://addons.mozilla.org/firefox/addon/refcontrol/\">RefControl</a> extension for per domain settings.",
         "config": [
             {
                 "network.http.sendRefererHeader": 0
-            }, 
+            },
             {
                 "network.http.referer.XOriginPolicy": 2
-            }, 
+            },
             {
                 "network.http.referer.spoofSource": true
-            }, 
+            },
             {
                 "network.http.referer.trimmingPolicy": 2
-            }, 
+            },
             {
                 "network.http.sendRefererHeader": 1
-            }, 
-            {}, 
+            },
             {}
-        ], 
-        "initial": 2, 
-        "type": "choice", 
+        ],
+        "initial": 2,
+        "type": "choice",
         "label": "Block Referer"
     }
 ]

--- a/settings/sessionstore_privacy.json
+++ b/settings/sessionstore_privacy.json
@@ -1,0 +1,30 @@
+[
+    {
+        "choices": [
+            "Store extra session data for any site (Default starting with Firefox 4)",
+            "Store extra session data for unencrypted (non-HTTPS) sites only (Default before Firefox 4)",
+            "Never store extra session data"
+        ],
+        "name": "sessionstore_privacy",
+        "addons": [
+            [],
+            [],
+            []
+        ],
+        "help_text": "This preference controls when to store extra information about a session: contents of forms, scrollbar positions, cookies, and POST data.",
+        "config": [
+            {
+                "browser.sessionstore.privacy_level": 0
+            },
+            {
+                "browser.sessionstore.privacy_level": 1
+            },
+            {
+                "browser.sessionstore.privacy_level": 2
+            }
+        ],
+        "initial": 2,
+        "type": "choice",
+        "label": "Sessionstore Privacy"
+    }
+]

--- a/settings/temporarycontainers.json
+++ b/settings/temporarycontainers.json
@@ -1,0 +1,23 @@
+[
+    {
+        "name": "temporarycontainers",
+        "type": "boolean",
+        "initial": true,
+        "label": "Install <a href=\"https://addons.mozilla.org/en-US/firefox/addon/temporary-containers/\">Temporary Containers</a> extension.",
+        "help_text": "Allows you to open tabs, websites, and links in automatically managed disposable containers.",
+        "addons": [
+            "TemporaryContainers@stoically.xpi"
+        ],
+        "config": {
+            "extensions.TemporaryContainers@stoically.whiteList": ""
+        },
+        "enterprise_policy": {
+			"ExtensionSettings": {
+				"TemporaryContainers@stoically": {
+					"install_url": "https://addons.mozilla.org/firefox/downloads/latest/temporary-containers/latest.xpi",
+					"installation_mode": "normal_installed"
+				}
+			}
+		}
+    }
+]

--- a/settings/trackingprotection.json
+++ b/settings/trackingprotection.json
@@ -8,7 +8,9 @@
         "addons": [], 
         "config": {
             "privacy.trackingprotection.pbmode.enabled": true, 
-            "privacy.trackingprotection.enabled": true
+            "privacy.trackingprotection.enabled": true,
+            "privacy.trackingprotection.fingerprinting.enabled": true,
+            "privacy.trackingprotection.cryptomining.enabled": true
         }
     }
 ]


### PR DESCRIPTION
Hi,

I added the missing parameters from [PrivacyTools](https://www.privacytools.io/browsers):

- privacy.trackingprotection.fingerprinting.enabled = true
- privacy.trackingprotection.cryptomining.enabled = true
- media.eme.enabled = false
- media.gmp-widevinecdm.enabled = false
- network.http.referer.XOriginTrimmingPolicy = 2
- browser.sessionstore.privacy_level = 2
- network.dns.disablePrefetchFromHTTPS = true
- network.predictor.enabled = false
- network.predictor.enable-prefetch = false

And AddOns from the same website

- [CookieAutoDelete@kennydo.xpi](https://addons.mozilla.org/firefox/downloads/file/954445/cookie_autodelete-2.2.0-an+fx.xpi)
- [Decentraleyes@ThomasRientjes.xpi](https://addons.mozilla.org/firefox/downloads/file/3539177/decentraleyes-2.0.14-an+fx.xpi)
- [ClearURLs@kevinr.xpi](https://addons.mozilla.org/firefox/downloads/file/3612592/clearurls-1.19.0-an+fx.xpi)
- [TemporaryContainers@stoically.xpi](https://addons.mozilla.org/firefox/downloads/file/3623550/temporary_containers-1.9.1-fx.xpi)
- [FirefoxMulti-AccountContainers@mozilla.org.xpi](https://addons.mozilla.org/firefox/downloads/file/3650825/firefox_multi_account_containers-7.1.0-fx.xpi)
