### PR TITLE
fixed about:config warning bool

### DIFF
--- a/settings/aboutconfig_warning.json
+++ b/settings/aboutconfig_warning.json
@@ -7,7 +7,7 @@
         "help_text": null, 
         "addons": [], 
         "config": {
-            "general.warnOnAboutConfig": false
+            "browser.aboutConfig.showWarning": false
         }
     }
 ]


### PR DESCRIPTION
After using the thing I noticed that I'm still getting the `about:config` warning even though I have `general.warnOnAboutConfig` set to `false` in `prefs.js`, after a bit of search I figured that the setting is called `browser.aboutConfig.showWarning` on my firefox (82.0.2 64-bit).

I'll assume this worked on older versions of FF, I don't know if you'd want to set the right one depending on the version or maybe set them both to false in that way feel free to edit my PR.