### PR TITLE
add pdf_js

### DIFF
--- a/profiles/01_default.json
+++ b/profiles/01_default.json
@@ -31,7 +31,8 @@
             "media_drm.json",
             "media_widevinecdm.json",
             "sensors.json",
-            "firefox_suggest.json"
+            "firefox_suggest.json",
+            "pdf_js.json"
         ], 
         "Privacy": [
             "useragent.json", 

--- a/settings/pdf_js.json
+++ b/settings/pdf_js.json
@@ -1,0 +1,13 @@
+[
+    {
+        "name": "pdf_js", 
+        "type": "boolean", 
+        "initial": false, 
+        "label": "Disable Javascript in PDF viewer", 
+        "help_text": "Disables executing of JavaScript in the PDF form viewer. It is possible that some PDFs are not rendered correctly due to missing functions.", 
+        "addons": [], 
+        "config": {
+            "pdfjs.enableScripting": false
+        }
+    }
+]


### PR DESCRIPTION
From [this stackoverflow answer](https://security.stackexchange.com/a/248985) disabling is not very important, because:
> that's not any different from any web page or framed web advertisement you browse to all day. It doesn't seem to be a problem in practice given equally "vulnerable" PDF viewers in Chrome, Edge, and Opera. You can always just close the tab as you would with a bad web page

see #224