### PR TITLE
Added optional Bitwarden addon

### DIFF
--- a/settings/bitwarden.json
+++ b/settings/bitwarden.json
@@ -1,0 +1,21 @@
+[
+    {
+        "name": "bitwarden", 
+        "type": "boolean", 
+        "initial": false, 
+        "label": "Install <a href=\"https://addons.mozilla.org/en-US/firefox/addon/bitwarden-password-manager/\">Bitwarden - Free Password Manager</a> extension.", 
+        "help_text": "A secure and free password manager for all of your devices.", 
+        "addons": [
+            "{446900e4-71c2-419f-a6a7-df9c091e268b}"
+        ], 
+        "config": {},
+        "enterprise_policy": {
+			"ExtensionSettings": {
+				"{446900e4-71c2-419f-a6a7-df9c091e268b}": {
+					"install_url": "https://addons.mozilla.org/firefox/downloads/latest/bitwarden-password-manager/latest.xpi",
+					"installation_mode": "normal_installed"
+				}
+			}
+		}
+    }
+]


### PR DESCRIPTION
According to [this](https://support.mozilla.org/en-US/questions/1217302) forum post, I extracted the extension id from the manifest.json file. The contribution wiki doesn't say how to further integrate this json to show up in the Addons page of the profile maker. Please let me know, how to do this, because I am planning on adding a couple additional useful addons. Please let me know if that is unwanted, but in my case it would be awesome to have all needed extensions installed from the start. The two extensions that come to mind are [cliget](https://addons.mozilla.org/en-US/firefox/addon/cliget/) and [Offline QR Code Generator](https://addons.mozilla.org/en-US/firefox/addon/offline-qr-code-generator)