### PR TITLE
Adding Native HTTPS Only Support

### DIFF
--- a/profiles/01_default.json
+++ b/profiles/01_default.json
@@ -70,6 +70,7 @@
         "Security": [
             "autoupdate.json", 
             "extension_blocklist.json",
+            "https_only.json",
             "punycode.json"
         ], 
         "Addons": [

--- a/settings/https_only.json
+++ b/settings/https_only.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "https_only", 
+        "type": "boolean", 
+        "initial": true, 
+        "label": "Enable HTTPS only mode", 
+        "help_text": "If enabled, allows connections only to sites that use the HTTPS protocol.", 
+        "addons": [], 
+        "config": {
+            "dom.security.https_only_mode": true,
+            "dom.security.https_only_mode_ever_enabled": true
+        }
+    }
+]

--- a/settings/https_only.json
+++ b/settings/https_only.json
@@ -2,7 +2,7 @@
     {
         "name": "https_only", 
         "type": "boolean", 
-        "initial": true, 
+        "initial": false, 
         "label": "Enable HTTPS only mode", 
         "help_text": "If enabled, allows connections only to sites that use the HTTPS protocol.", 
         "addons": [], 


### PR DESCRIPTION
Firefox has native support for only connecting to HTTPS sites. I added
the ability to add these to the generated prefs.js file.