### PR TITLE
dnt initial set to false

### DIFF
--- a/settings/dnt.json
+++ b/settings/dnt.json
@@ -2,7 +2,7 @@
     {
         "name": "dnt", 
         "type": "boolean", 
-        "initial": true, 
+        "initial": false, 
         "label": "Enable Do-not-Track", 
         "help_text": "With the do not track feature, you tell websites, that you do not want to be tracked. Most websites ignore this, so you need other privacy options as well.", 
         "addons": [], 


### PR DESCRIPTION
The dnt request is almost always ignored, thus provides no real benefit
to being turned on by default. As it only sends more data to websites
that are visited.